### PR TITLE
【ねんがんの】ファイル分割に対応

### DIFF
--- a/app/models/seed_part.rb
+++ b/app/models/seed_part.rb
@@ -1,0 +1,109 @@
+class SeedPart < ActiveRecord::Base
+  extend Memoist
+
+  belongs_to :seed_table
+  scope :by_seed_table_id, ->(seed_table_id) { where(:seed_table_id => seed_table_id) }
+
+  attr_accessor :file, :target_model
+
+  WHOLE_ID_RANGE = (1 .. (2 ** 31 - 1))
+  PART_INFO_STRUCT = Struct.new(:id_range, :file_path, :updated, :digest, :values)
+
+  def updated?
+    !stable?
+  end
+  memoize :updated?
+
+  def stable?
+    self.file.digest == self.digest
+  end
+  memoize :stable?
+
+  def values
+    self.file.values
+  end
+  memoize :values
+
+  def new_ids
+    self.values.map { |v| v[:id] }
+  end
+  memoize :new_ids
+
+  def existing_ids
+    target_model.where(:id => (self.record_id_from .. self.record_id_to)).pluck(:id)
+  end
+  memoize :existing_ids
+
+  def existing_ids_as_hash
+    hash = {}
+    existing_ids.each do |v|
+      hash[v] = true
+    end
+    hash
+  end
+  memoize :existing_ids_as_hash
+
+  def existing_digests
+    digests = {}
+    records =
+      SeedRecord.where(:seed_table_id => seed_table.id,
+                       :record_id => self.record_id_from .. self.record_id_to).
+      pluck([:record_id, :digest])
+
+    records.each do |record_id, digest|
+      digests[record_id] = digest
+    end
+
+    digests
+  end
+  memoize :existing_digests
+
+  def update_digest!
+    self.digest = self.file.digest
+    self.save!
+  end
+
+  private
+
+  class << self
+    def setup(seed_table, id_range, file_info, db_info)
+      record = if db_info
+                 db_info
+               else
+                 self.new(:seed_table_id  => seed_table.id,
+                          :record_id_from => id_range.min,
+                          :record_id_to   => id_range.max)
+               end
+
+      record.file = SeedExpress::File.new(file_info, seed_table.reader)
+      record.target_model = seed_table.target_model
+      record
+    end
+
+    def part_files(pattern)
+      part_files = {}
+      Dir.glob(pattern).each do |file|
+        next unless %r!\.([0-9]+)-([0-9]+)\.csv$!i === file
+
+        id_from = $1.to_i
+        id_to = $2.to_i
+        if id_from > id_to
+          raise "Incorrect partail file name(#{file})"
+        end
+
+        id_range = id_from .. id_to
+        part_files[id_range] = PART_INFO_STRUCT.new(id_range, file)
+      end
+
+      part_files.present? ? part_files : nil
+    end
+
+    def files(pattern)
+      return nil unless File.exists?(pattern)
+
+      {
+        WHOLE_ID_RANGE => PART_INFO_STRUCT.new(WHOLE_ID_RANGE, pattern)
+      }
+    end
+  end
+end

--- a/app/models/seed_record.rb
+++ b/app/models/seed_record.rb
@@ -1,3 +1,113 @@
 class SeedRecord < ActiveRecord::Base
   belongs_to :seed_table
+  scope :by_seed_table_id, ->(seed_table_id) { where(:seed_table_id => seed_table_id) }
+  scope :by_record_id, ->(record_id) { where(:record_id => record_id) }
+  scope :by_out_of_parts, ->(parts) {
+    in_range = parts.map do |part|
+      "(record_id BETWEEN #{part.record_id_from} AND #{part.record_id_to})"
+    end.join(' OR ')
+    where("NOT (#{in_range})")
+  }
+
+  BLOCK_SIZE = 5000
+
+  class << self
+    def renew_digests!(seed_express, inserted_ids, updated_ids, new_digests)
+      pending_records = update_digests!(seed_express, updated_ids, new_digests)
+      inserting_records = make_bulk_digest_records(seed_express, inserted_ids, new_digests)
+      insert_digests!(seed_express, inserting_records + pending_records)
+      delete_digests_out_of!(seed_express.parts)
+    end
+
+    private
+
+    def update_digests!(seed_express, updated_ids, new_digests)
+      tmp_updated_ids = updated_ids.dup
+      inserting_records = []
+
+      existing_digests = self.all.index_by(&:record_id)
+      counter = 0
+      seed_express.callbacks[:before_updating_digests].call(counter, updated_ids.size)
+      while tmp_updated_ids.present?
+        seed_express.callbacks[:before_updating_a_part_of_digests].call(counter, updated_ids.size)
+        updating_records = []
+        targets = tmp_updated_ids.slice!(0, BLOCK_SIZE)
+        targets.each do |id|
+          seed_record = existing_digests[id]
+          if seed_record
+            seed_record.digest = new_digests[id]
+            updating_records << seed_record
+          else
+            inserting_records <<
+              self.new(:record_id => id, :digest => new_digests[id])
+          end
+        end
+
+        bulk_update_digests!(updating_records)
+        counter += targets.size
+        seed_express.callbacks[:after_updating_a_part_of_digests].call(counter, updated_ids.size)
+      end
+
+      seed_express.callbacks[:after_updating_digests].call(counter, updated_ids.size)
+      inserting_records
+    end
+
+    def make_bulk_digest_records(seed_express, inserted_ids, new_digests)
+      counter = 0
+      inserting_records = []
+      seed_express.callbacks[:before_making_bulk_digest_records].call(0, inserted_ids.size)
+      inserted_ids.each do |id|
+        if counter % BLOCK_SIZE == 0
+          seed_express.callbacks[:before_making_a_part_of_bulk_digest_records].call(counter, inserted_ids.size)
+        end
+
+        inserting_records <<
+          self.new(:record_id => id, :digest => new_digests[id])
+
+        counter += 1
+        if counter % BLOCK_SIZE == 0
+          seed_express.callbacks[:after_making_a_part_of_bulk_digest_records].call(counter, inserted_ids.size)
+        end
+      end
+
+      seed_express.callbacks[:after_making_bulk_digest_records].call(inserted_ids.size, inserted_ids.size)
+      inserting_records
+    end
+
+    def insert_digests!(seed_express, bulk_records)
+      counter = 0
+      seed_express.callbacks[:before_inserting_digests].call(counter, bulk_records.size)
+      while bulk_records.present?
+        seed_express.callbacks[:before_inserting_a_part_of_digests].call(counter, bulk_records.size)
+        targets = bulk_records.slice!(0, BLOCK_SIZE)
+        SeedRecord.import(targets)
+        counter += targets.size
+        seed_express.callbacks[:after_inserting_a_part_of_digests].call(counter, bulk_records.size)
+      end
+      seed_express.callbacks[:after_inserting_digests].call(counter, bulk_records.size)
+    end
+
+    def bulk_update_digests!(records)
+      return if records.empty?
+
+      ids = records.map(&:id).join(',')
+      digests = records.map { |v| "'#{v.digest}'"  }.join(',')
+      updated_at = "'" + Time.zone.now.utc.strftime('%Y-%m-%dT%H:%M:%S') + "'"
+
+      sql = <<-"EOF"
+        UPDATE seed_records
+        SET
+          updated_at = #{updated_at},
+          digest = ELT(FIELD(id, #{ids}), #{digests})
+        WHERE
+          id IN (#{ids})
+      EOF
+
+      ActiveRecord::Base.connection.execute(sql)
+    end
+
+    def delete_digests_out_of!(parts)
+      self.by_out_of_parts(parts).delete_all
+    end
+  end
 end

--- a/db/migrate/20140623225119_create_seed_tables.rb
+++ b/db/migrate/20140623225119_create_seed_tables.rb
@@ -1,16 +1,11 @@
 class CreateSeedTables < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :seed_tables do |t|
       t.string :table_name, :null => false
       t.string :digest,     :null => true
       t.timestamps :null => true
     end
 
-    add_index :seed_tables, [:table_name], unique: true, name: :idx_seed_tables_001
-  end
-
-  def self.down
-    remove_table :seed_tables
-    remove_index :idx_seed_tables_001
+    add_index :seed_tables, [:table_name], :unique => true, :name => :idx_seed_tables_001
   end
 end

--- a/db/migrate/20140623225222_create_seed_records.rb
+++ b/db/migrate/20140623225222_create_seed_records.rb
@@ -7,7 +7,7 @@ class CreateSeedRecords < ActiveRecord::Migration
       t.timestamps null: true
     end
 
-    add_index :seed_records, [:seed_table_id], name: :idx_seed_records_001
-    add_index :seed_records, [:seed_table_id, :record_id], unique: true, name: :idx_seed_records_002
+    add_index :seed_records, [:seed_table_id], :name => :idx_seed_records_001
+    add_index :seed_records, [:seed_table_id, :record_id], :unique => true, :name => :idx_seed_records_002
   end
 end

--- a/db/migrate/20150822140058_create_seed_parts.rb
+++ b/db/migrate/20150822140058_create_seed_parts.rb
@@ -1,0 +1,16 @@
+class CreateSeedParts < ActiveRecord::Migration
+  def change
+    create_table :seed_parts do |t|
+      t.references :seed_table,      :null => false
+      t.integer    :record_id_from,  :null => false
+      t.integer    :record_id_to,    :null => false
+      t.string     :digest,          :null => true
+      t.timestamps                   :null => true
+    end
+
+    add_index(:seed_parts,
+              [:seed_table_id, :record_id_from, :record_id_to],
+              :name => :idx_seed_parts_001,
+              :unique => true)
+  end
+end

--- a/db/migrate/20150822155846_remove_digest_from_seed_tables.rb
+++ b/db/migrate/20150822155846_remove_digest_from_seed_tables.rb
@@ -1,0 +1,5 @@
+class RemoveDigestFromSeedTables < ActiveRecord::Migration
+  def change
+    remove_column :seed_tables, :digest
+  end
+end

--- a/db/migrate/20160622183708_remove_an_obsolete_index_from_seed_records.rb
+++ b/db/migrate/20160622183708_remove_an_obsolete_index_from_seed_records.rb
@@ -1,0 +1,5 @@
+class RemoveAnObsoleteIndexFromSeedRecords < ActiveRecord::Migration
+  def change
+    remove_index :seed_records, :name => :idx_seed_records_001
+  end
+end

--- a/lib/seed_express.rb
+++ b/lib/seed_express.rb
@@ -3,8 +3,13 @@ require 'rails'
 require "seed_express/version"
 
 module SeedExpress
-  autoload :Railtie,  'seed_express/railtie'
+  autoload :Railtie,    'seed_express/railtie'
   Railtie
-  autoload :Abstract, 'seed_express/abstract'
-  autoload :CSV,      'seed_express/csv'
+  autoload :Abstract,   'seed_express/abstract'
+  autoload :CSV,        'seed_express/csv'
+  autoload :Parts,      'seed_express/parts'
+  autoload :Part,       'seed_express/part'
+  autoload :Converter,  'seed_express/converter'
+  autoload :File,       'seed_express/file'
+  autoload :Supporters, 'seed_express/supporters'
 end

--- a/lib/seed_express.rb
+++ b/lib/seed_express.rb
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 require 'rails'
+require 'pp'
+require 'msgpack'
+require 'memoist'
 require "seed_express/version"
 
 module SeedExpress

--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -2,6 +2,9 @@ module SeedExpress
   class Abstract
     require 'pp'
     require 'msgpack'
+    require 'memoist'
+
+    extend Memoist
 
     attr_accessor :table_name
     attr_accessor :truncate_mode
@@ -11,24 +14,15 @@ module SeedExpress
     attr_accessor :callbacks
     attr_accessor :parent_validation
 
-    @@table_to_klasses = nil
-
-    DEFAULT_NVL_CONVERSIONS = {
-      :integer => 0,
-      :string => '',
-    }
-
-    DEFAULT_CONVERSIONS = {
-      :datetime => ->(seed_express, value) { Time.zone.parse(value) + seed_express.datetime_offset },
-    }
-
     def initialize(table_name, path, options)
+      Supporters.regist!
+
       @table_name = table_name
       @path = path
 
       @filter_proc = options[:filter_proc]
       default_callback_proc = Proc.new { |*args| }
-      default_callbacks = [:truncating, :disabling_record_cache,
+      default_callbacks = [:truncating, :disabling_digests,
                            :reading_data, :deleting,
                            :inserting, :inserting_a_part,
                            :updating, :updating_a_part,
@@ -37,8 +31,7 @@ module SeedExpress
                            :making_bulk_digest_records, :making_a_part_of_bulk_digest_records,
                           ].flat_map do |v|
         ["before_#{v}", "after_#{v}"].map(&:to_sym)
-      end.flat_map { |v| [v, default_callback_proc ] }
-      default_callbacks = Hash[*default_callbacks]
+      end.map { |v| [v, default_callback_proc ] }.to_h
       @callbacks = default_callbacks.merge(options[:callbacks] || {})
 
       self.truncate_mode = options[:truncate_mode]
@@ -48,78 +41,99 @@ module SeedExpress
       self.parent_validation = options[:parent_validation]
     end
 
-    def klass
-      return @klass if @klass
-      @klass = self.class.table_to_klasses[@table_name]
-      unless @klass
+    def file_pattern
+      "#{@path}/#{table_name}.#{self.class::FILE_SUFFIX}"
+    end
+    memoize :file_pattern
+
+    def part_file_pattern
+      "#{@path}/#{table_name}.*-*.#{self.class::FILE_SUFFIX}"
+    end
+    memoize :part_file_pattern
+
+    def target_model
+      unless v = self.class.table_to_klasses[@table_name]
         raise "#{@table_name} isn't able to convert to a class object"
       end
-
-      @klass
+      v
     end
+    memoize :target_model
 
     def seed_table
-      @seed_table ||= SeedTable.get_record(@table_name)
+      obj = SeedTable.get_record(target_model)
+      obj.reader = self
+      obj
     end
+    memoize :seed_table
 
-    def table_digest
-      return @table_digest if @table_digest
-      @table_digest = Digest::SHA1.hexdigest(File.read(file_name))
+    def parts
+      seed_table.parts
     end
+    memoize :parts
+
+    def converters
+      Converter.new(target_model,
+                    :nvl_mode        => nvl_mode,
+                    :datetime_offset => datetime_offset
+                    )
+    end
+    memoize :converters
 
     def truncate_table
       callbacks[:before_truncating].call
-      klass.connection.execute("TRUNCATE TABLE #{@table_name};")
-      SeedRecord.where(seed_table_id: seed_table.id).delete_all
+      ActiveRecord::Base.transaction do
+        seed_table.truncate_digests
+      end
+
+      target_model.connection.execute("TRUNCATE TABLE #{@table_name}")
       callbacks[:after_truncating].call
     end
 
-    def disable_record_cache
-      callbacks[:before_disabling_record_cache].call
-      seed_table.disable_record_cache
-      callbacks[:after_disabling_record_cache].call
+    def disable_digests
+      callbacks[:before_disabling_digests].call
+      ActiveRecord::Base.transaction do
+        seed_table.disable_record_digests
+      end
+      callbacks[:before_disabling_digests].call
     end
 
     def in_records
       raise "Please implements #in_records in each class"
     end
 
-    def duplicate_ids(values)
-      hash = Hash.new(0)
-      values.each do |value|
-        hash[value[:id]] += 1
-      end
-      hash.delete_if do |k, v|
-        v == 1
-      end
+    def import
+      beginning_time = Time.zone.now
 
-      hash
-    end
-
-    def import_csv
       if truncate_mode
         truncate_table
       elsif force_update_mode
-        disable_record_cache
-      elsif seed_table.digest == table_digest
-        # テーブルのダイジェスト値が同じ場合は処理をスキップする
-        return {:result => :skipped}
+        disable_digests
       end
 
-      # 削除されるレコードを削除
-      deleted_ids = delete_missing_data
+      digests = {}
+      deleted_ids = []
+      inserted_ids = []
+      inserted_error = false
+      updated_ids = []
+      actual_updated_ids = []
+      updated_error = false
 
-      # 新規登録対象と更新対象に分離
-      inserting_records, updating_records, digests = take_out_each_types_of_data_to_upload
+      # パート毎に処理する
+      parts_updated = false
+      self.parts.each.with_index(1) do |part, i|
+        next unless part.updated?
+        out_of_part = SeedExpress::Part.new(part, converters, callbacks, i, parts.size).import
+        digests.merge!(out_of_part[0])
+        deleted_ids        += out_of_part[1]
+        inserted_ids       += out_of_part[2]
+        inserted_error     |= out_of_part[3]
+        updated_ids        += out_of_part[4]
+        actual_updated_ids += out_of_part[5]
+        updated_error      |= out_of_part[6]
+        parts_updated = true
+      end
 
-      # 新規登録するレコードを更新
-      inserted_ids, inserted_error = insert_records(inserting_records)
-
-      # 更新するレコードを更新
-      updated_ids, actual_updated_ids, updated_error = update_records(updating_records)
-
-      # 不要な digest を削除
-      delete_waste_seed_records
+      return {:result => :skipped, :elapsed_time => Time.zone.now - beginning_time} unless parts_updated
 
       # 処理後の Validation
       after_seed_express_error =
@@ -136,292 +150,29 @@ module SeedExpress
 
       has_an_error = inserted_error || updated_error || after_seed_express_error
       unless has_an_error
-        # ダイジェスト値の更新
-        update_digests(inserted_ids, updated_ids, digests)
-
-        # テーブルダイジェストを更新
-        seed_table.update_attributes!(:digest => table_digest)
+        ActiveRecord::Base.transaction do
+          seed_table.seed_records.renew_digests!(self, inserted_ids, updated_ids, digests)
+          self.parts.renew_digests!
+        end
       end
 
       result = has_an_error ? :error : :result
+      elapsed_time = Time.zone.now - beginning_time
 
       return {
         :result               => result,
         :inserted_count       => inserted_ids.size,
         :updated_count        => updated_ids.size,
         :actual_updated_count => actual_updated_ids.size,
-        :deleted_count        => deleted_ids.size
+        :deleted_count        => deleted_ids.size,
+        :elapsed_time         => elapsed_time,
       }
     end
 
-    def convert_value(column, value)
-      if value.nil?
-        return defaults_on_db[column] if defaults_on_db.has_key?(column)
-        return nvl(column, value)
-      end
-      conversion = DEFAULT_CONVERSIONS[columns[column].type]
-      return value unless conversion
-      conversion.call(self, value)
-    end
-
-    def defaults_on_db
-      return @defaults_on_db if @defaults_on_db
-      @defaults_on_db = {}
-      klass.columns.each do |column|
-        unless column.default.nil?
-          @defaults_on_db[column.name.to_sym] = column.default
-        end
-      end
-      @defaults_on_db
-    end
-
-    def nvl(column, value)
-      return nil unless nvl_mode
-      nvl_columns[column]
-    end
-
-    def nvl_columns
-      return @nvl_columns if @nvl_columns
-      @nvl_columns = {}
-      klass.columns.each do |column|
-        @nvl_columns[column.name.to_sym] = DEFAULT_NVL_CONVERSIONS[column.type]
-      end
-
-      @nvl_columns
-    end
-
-    def columns
-      return @columns if @columns
-      @columns = klass.columns.index_by { |column| column.name.to_sym }
-      @columns.default_proc = lambda { |h, k| raise "#{klass.to_s}##{k} is not found" }
-      @columns
-    end
-
-    def existing_ids
-      return @existing_ids if @existing_ids
-
-      @existing_ids = {}
-      klass.select(:id).map(&:id).each do |id|
-        @existing_ids[id] = true
-      end
-
-      @existing_ids
-    end
-
-    def delete_missing_data
-      new_ids = in_records.map { |value| value[:id] }
-      delete_target_ids = existing_ids.keys - new_ids
-      if delete_target_ids.present?
-        callbacks[:before_deleting].call(delete_target_ids.size)
-        klass.where(id: delete_target_ids).delete_all
-      end
-
-      callbacks[:after_deleting].call(delete_target_ids.size)
-      delete_target_ids
-    end
-
-    def existing_digests
-      existing_digests = {}
-      SeedRecord.where(seed_table_id: seed_table.id).map do |record|
-        existing_digests[record.record_id] = record.digest
-      end
-
-      existing_digests
-    end
-
-    def take_out_each_types_of_data_to_upload
-      inserting_records = []
-      updating_records = []
-      digests = {}
-
-      duplicate_ids = duplicate_ids(in_records)
-      if duplicate_ids.present?
-        raise "There are dupilcate ids. ({id=>num}: #{duplicate_ids.inspect})"
-      end
-
-      existing_digests = self.existing_digests
-      in_records.each do |value|
-        id = value[:id]
-        digest  = Digest::SHA1.hexdigest(MessagePack.pack(value))
-
-        if existing_ids[id]
-          if existing_digests[id] != digest
-            updating_records << value
-            digests[id] = digest
-          end
-        else
-          inserting_records << value
-          digests[id] = digest
-        end
-      end
-
-      return inserting_records, updating_records, digests
-    end
-
-    def insert_records(records)
-      error = false
-      records_count = records.size
-      callbacks[:before_inserting].call(records_count)
-      block_size = 1000
-
-      existing_record_count =
-        ActiveRecord::Base.transaction { klass.count }  # To read from master server
-
-      inserted_ids = []
-      while(records.present?) do
-        callbacks[:before_inserting_a_part].call(inserted_ids.size, records_count)
-        targets = records.slice!(0, block_size)
-
-        # マスタ本体をアップデート
-        bulk_records = targets.map do |attributes|
-          model = klass.new
-          attributes.each_pair do |column, value|
-            model[column] = convert_value(column, value)
-          end
-
-          if model.valid?
-            inserted_ids << attributes[:id]
-            model
-          else
-            STDOUT.puts
-            STDOUT.puts "When id is #{model.id}: "
-            STDOUT.print get_errors(model.errors).pretty_inspect
-            error = true
-            nil
-          end
-        end.compact
-        v = klass.import(bulk_records, :on_duplicate_key_update => [:id])
-        callbacks[:after_inserting_a_part].call(inserted_ids.size, records_count)
-      end
-
-      current_record_count =
-        ActiveRecord::Base.transaction { klass.count }  # To read from master server
-      if current_record_count != existing_record_count + records_count
-        raise "Inserting error has been detected. Maybe it's caused by duplicated key on not ID column. Try truncate mode."
-      end
-
-      callbacks[:after_inserting].call(inserted_ids.size)
-      return inserted_ids, error
-    end
-
-    def update_records(records)
-      error = false
-      records_count = records.size
-      callbacks[:before_updating].call(records_count)
-      block_size = 1000
-
-      updated_ids = []
-      actual_updated_ids = []
-      while(records.present?) do
-        callbacks[:before_updating_a_part].call(updated_ids.size, records_count)
-        targets = records.slice!(0, block_size)
-        record_ids = targets.map { |target| target[:id] }
-
-        existing_records = klass.where(id: record_ids).index_by(&:id)
-        ActiveRecord::Base.transaction do
-          bulk_seed_records = []
-          targets.each do |attributes|
-            id = attributes[:id]
-            model = existing_records[id]
-            attributes.each_pair do |column, value|
-              model[column] = convert_value(column, value)
-            end
-            if model.changed?
-              if model.valid?
-                model.save!
-                actual_updated_ids << id
-              else
-                STDOUT.puts
-                STDOUT.puts "When id is #{model.id}: "
-                STDOUT.print get_errors(model.errors).pretty_inspect
-                error = true
-              end
-            end
-            updated_ids << id
-          end
-          SeedRecord.import(bulk_seed_records)
-        end
-        callbacks[:before_updating_a_part].call(updated_ids.size, records_count)
-      end
-
-      callbacks[:after_updating].call(updated_ids.size)
-      return updated_ids, actual_updated_ids, error
-    end
-
-    def delete_waste_seed_records
-      master_record_ids = klass.all.map(&:id)
-      seed_record_ids = SeedRecord.where(seed_table_id: seed_table.id).map(&:record_id)
-      waste_record_ids = seed_record_ids - master_record_ids
-
-      SeedRecord.where(seed_table_id: seed_table.id,
-                       record_id: waste_record_ids).delete_all
-    end
-
-    def update_digests(inserted_ids, updated_ids, digests)
-      tmp_updated_ids = updated_ids.dup
-      block_size = 1000
-      bulk_records = []
-
-      existing_digests = SeedRecord.where(seed_table_id: seed_table.id,
-                                          record_id: updated_ids).index_by(&:record_id)
-      counter = 0
-      callbacks[:before_updating_digests].call(counter, updated_ids.size)
-      while tmp_updated_ids.present?
-        callbacks[:before_updating_a_part_of_digests].call(counter, updated_ids.size)
-        updating_records = []
-        targets = tmp_updated_ids.slice!(0, block_size)
-        targets.each do |id|
-          seed_record = existing_digests[id]
-          if seed_record
-            seed_record.digest = digests[id]
-            updating_records << seed_record
-          else
-            bulk_records << SeedRecord.new(seed_table_id: seed_table.id,
-                                           record_id:     id,
-                                           digest:        digests[id])
-          end
-        end
-
-        bulk_update_digests(updating_records)
-        counter += targets.size
-        callbacks[:after_updating_a_part_of_digests].call(counter, updated_ids.size)
-      end
-      callbacks[:after_updating_digests].call(counter, updated_ids.size)
-
-      counter = 0
-      callbacks[:before_making_bulk_digest_records].call(0, inserted_ids.size)
-      inserted_ids.each do |id|
-        if counter % block_size == 0
-          callbacks[:before_making_a_part_of_bulk_digest_records].call(counter, inserted_ids.size)
-        end
-
-        bulk_records << SeedRecord.new(seed_table_id: seed_table.id,
-                                       record_id:     id,
-                                       digest:        digests[id])
-        counter += 1
-        if counter % block_size == 0
-          callbacks[:after_making_a_part_of_bulk_digest_records].call(counter, inserted_ids.size)
-        end
-      end
-      callbacks[:after_making_bulk_digest_records].call(inserted_ids.size, inserted_ids.size)
-
-      bulk_size = bulk_records.size
-      counter = 0
-      callbacks[:before_inserting_digests].call(counter, bulk_size)
-      while bulk_records.present?
-        callbacks[:before_inserting_a_part_of_digests].call(counter, bulk_size)
-        targets = bulk_records.slice!(0, block_size)
-        SeedRecord.import(targets)
-        counter += targets.size
-        callbacks[:after_inserting_a_part_of_digests].call(counter, bulk_size)
-      end
-      callbacks[:after_inserting_digests].call(counter, bulk_size)
-    end
-
     def after_seed_express_validation(args)
-      return false unless klass.respond_to?(:after_seed_express_validation)
+      return false unless target_model.respond_to?(:after_seed_express_validation)
 
-      errors, = klass.after_seed_express_validation(args)
+      errors, = target_model.after_seed_express_validation(args)
       error = false
       if errors.present?
         STDOUT.puts
@@ -432,16 +183,18 @@ module SeedExpress
       return error
     end
 
-    def self.table_to_klasses
-      return @@table_to_klasses if @@table_to_klasses
+    class << self
+      extend Memoist
 
-      # Enables full of models
-      Find.find("#{Rails.root}/app/models") { |f| require f if /\.rb$/ === f }
+      def table_to_klasses
+        # Enables full of models
+        Find.find("#{Rails.root}/app/models") { |f| require f if /\.rb$/ === f }
 
-      table_to_klasses = ActiveRecord::Base.subclasses.
-        select { |klass| klass.respond_to?(:table_name) }.
-        flat_map { |klass| [klass.table_name.to_sym, klass] }
-      @@table_to_klasses = Hash[*table_to_klasses]
+        table_to_klasses = ActiveRecord::Base.subclasses.
+          select { |klass| klass.respond_to?(:table_name) }.
+          map { |klass| [klass.table_name.to_sym, klass] }.to_h
+      end
+      memoize :table_to_klasses
     end
 
     private
@@ -462,29 +215,11 @@ module SeedExpress
       parent_table = self.parent_validation
       parent_id_column = (parent_table.to_s.singularize + "_id").to_sym
 
-      parent_ids = klass.where(:id => args[:inserted_ids] + args[:updated_ids]).
-        select(parent_id_column).group(parent_id_column).map(&parent_id_column)
+      parent_ids = target_model.where(:id => args[:inserted_ids] + args[:updated_ids]).
+        group(parent_id_column).pluck(parent_id_column)
 
-      SeedTable.get_record(parent_table).disable_record_cache(parent_ids)
-    end
-
-    def bulk_update_digests(records)
-      return if records.empty?
-
-      ids = records.map(&:id).join(',')
-      digests = records.map { |v| "'#{v.digest}'"  }.join(',')
-      updated_at = "'" + Time.zone.now.utc.strftime('%Y-%m-%dT%H:%M:%S') + "'"
-
-      sql = <<-"EOF"
-      UPDATE seed_records
-      SET
-        updated_at = #{updated_at},
-        digest = ELT(FIELD(id, #{ids}), #{digests})
-      WHERE
-        id IN (#{ids})
-    EOF
-
-      ActiveRecord::Base.connection.execute(sql)
+      parent_table_model = self.class.table_to_klasses[parent_table]
+      SeedTable.get_record(parent_table_model).disable_record_digests(parent_ids)
     end
   end
 end

--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -1,9 +1,5 @@
 module SeedExpress
   class Abstract
-    require 'pp'
-    require 'msgpack'
-    require 'memoist'
-
     extend Memoist
 
     attr_accessor :table_name

--- a/lib/seed_express/converter.rb
+++ b/lib/seed_express/converter.rb
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+module SeedExpress
+  class Converter
+    extend Memoist
+
+    DEFAULT_NVL_CONVERSIONS = {
+      :integer => 0,
+      :string => '',
+    }
+
+    DEFAULT_CONVERSIONS = {
+      :datetime => ->(converter, value) do
+        Time.zone.parse(value) + converter.datetime_offset
+      end,
+    }
+
+    attr_reader :target_model
+    attr_reader :nvl_mode
+    attr_reader :datetime_offset
+
+    def initialize(target_model, options)
+      @target_model = target_model
+      @nvl_mode = !!options[:nvl_mode]
+      @datetime_offset = options[:datetime_offset]
+    end
+
+    def convert_value(column, value)
+      if value.nil?
+        return defaults_on_db[column] if defaults_on_db.has_key?(column)
+        return nvl(column, value)
+      end
+      conversion = DEFAULT_CONVERSIONS[columns[column].type]
+      return value unless conversion
+      conversion.call(self, value)
+    end
+
+    def nvl(column, value)
+      return nil unless nvl_mode
+      nvl_columns[column]
+    end
+
+    private
+
+    def defaults_on_db
+      defaults = {}
+      target_model.columns.each do |column|
+        unless column.default.nil?
+          defaults[column.name.to_sym] = column.default
+        end
+      end
+      defaults
+    end
+    memoize :defaults_on_db
+
+    def nvl_columns
+      columns = {}
+      target_model.columns.each do |column|
+        columns[column.name.to_sym] = DEFAULT_NVL_CONVERSIONS[column.type]
+      end
+      columns
+    end
+    memoize :nvl_columns
+
+    def columns
+      columns = target_model.columns.index_by { |column| column.name.to_sym }
+      columns.default_proc = lambda { |h, k| raise "#{target_model.to_s}##{k} is not found" }
+      columns
+    end
+    memoize :columns
+  end
+end

--- a/lib/seed_express/file.rb
+++ b/lib/seed_express/file.rb
@@ -1,0 +1,34 @@
+module SeedExpress
+  class File
+    extend Memoist
+
+    attr_reader :id_range, :path, :digest, :values, :reader
+
+    def initialize(file_info, reader)
+      @file_info = file_info
+      return unless @file_info
+
+      @id_range = file_info.id_range
+      @path     = file_info.file_path
+      @reader   = reader
+    end
+
+    def digest
+      return unless @file_info
+      Digest::SHA1.hexdigest(data)
+    end
+    memoize :digest
+
+    def values
+      self.reader.read_values_from(data)
+    end
+    memoize :values
+
+    private
+
+    def data
+      ::File.read(self.path)
+    end
+    memoize :data
+  end
+end

--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+module SeedExpress
+  class Part
+    BLOCK_SIZE = 1000
+
+    extend Memoist
+
+    attr_reader :seed_part
+    attr_reader :callbacks
+    attr_reader :target_model
+    attr_reader :part_count
+    attr_reader :part_total
+    attr_reader :converters
+
+    def initialize(seed_part, converters, callbacks, part_count, part_total)
+      @seed_part = seed_part
+      @converters = converters
+      @target_model = seed_part.target_model
+      @callbacks = callbacks
+      @part_count = part_count
+      @part_total = part_total
+    end
+
+    def import
+      return unless seed_part.updated?
+
+      # ID 重複を検出
+      detect_duplicated_ids
+
+      # 削除されるレコードを削除
+      deleted_ids = delete_missing_data
+
+      # 新規登録対象と更新対象に分離
+      inserting_records, updating_records, digests =
+        categorize_each_types_of_data_to_upload
+
+      # 新規登録するレコードを更新
+      inserted_ids, inserted_error = insert_records(inserting_records)
+
+      # 更新するレコードを更新
+      updated_ids, actual_updated_ids, updated_error = update_records(updating_records)
+
+      # 不要な digest を削除
+      delete_waste_seed_records
+
+      return digests, deleted_ids, inserted_ids, inserted_error, updated_ids, actual_updated_ids, updated_error
+    end
+
+    private
+
+    def delete_missing_data
+      delete_target_ids = seed_part.existing_ids - seed_part.new_ids
+      callbacks[:before_deleting].call(delete_target_ids.size)
+      if delete_target_ids.present?
+        target_model.where(:id => delete_target_ids).delete_all
+      end
+      callbacks[:after_deleting].call(delete_target_ids.size)
+      delete_target_ids
+    end
+
+    def categorize_each_types_of_data_to_upload
+      inserting_records = []
+      updating_records = []
+      digests = {}
+
+      existing_ids = seed_part.existing_ids_as_hash
+      existing_digests = seed_part.existing_digests
+      seed_part.values.each do |value|
+        id = value[:id]
+        digest  = Digest::SHA1.hexdigest(MessagePack.pack(value))
+
+        if existing_ids[id]
+          if existing_digests[id] != digest
+            updating_records << value
+            digests[id] = digest
+          end
+        else
+          inserting_records << value
+          digests[id] = digest
+        end
+      end
+
+      return inserting_records, updating_records, digests
+    end
+
+    def detect_duplicated_ids
+      duplicated_ids = Hash.new(0)
+      seed_part.values.each do |value|
+        duplicated_ids[value[:id]] += 1
+      end
+      duplicated_ids.delete_if do |k, v|
+        v == 1
+      end
+
+      return duplicated_ids.blank?
+      raise "There are dupilcated ids. ({id=>num}: #{duplicated_ids.inspect})"
+    end
+
+    def insert_records(records)
+      error = false
+      records_count = records.size
+      callbacks[:before_inserting].call(records_count)
+
+      existing_record_count =
+        ActiveRecord::Base.transaction { target_model.count }  # To read certainly from master server
+
+      inserted_ids = []
+      while(records.present?) do
+        callbacks[:before_inserting_a_part].call(part_count, part_total, inserted_ids.size, records_count)
+        targets = records.slice!(0, BLOCK_SIZE)
+        out_inserted_ids, out_error = insert_a_block_of_records(targets)
+        inserted_ids += out_inserted_ids
+        error |= out_error
+        callbacks[:after_inserting_a_part].call(part_count, part_total, inserted_ids.size, records_count)
+      end
+
+      current_record_count =
+        ActiveRecord::Base.transaction { target_model.count }  # To read certainly from master server
+      if current_record_count != existing_record_count + records_count
+        raise "Inserting error has been detected. Maybe it's caused by duplicated key on not ID column. Try truncate mode."
+      end
+
+      callbacks[:after_inserting].call(inserted_ids.size)
+      return inserted_ids, error
+    end
+
+    def insert_a_block_of_records(records)
+      error = false
+      inserted_ids = []
+      bulk_records = records.map do |attributes|
+        record = target_model.new
+        attributes.each_pair do |column, value|
+          record[column] = converters.convert_value(column, value)
+        end
+
+        if record.valid?
+          inserted_ids << attributes[:id]
+          record
+        else
+          STDOUT.puts
+          STDOUT.puts "When id is #{record.id}: "
+          STDOUT.print get_errors(record.errors).pretty_inspect
+          error = true
+          nil
+        end
+      end.compact
+
+      target_model.import(bulk_records)
+      return inserted_ids, error
+    end
+
+    def update_records(records)
+      error = false
+      records_count = records.size
+      callbacks[:before_updating].call(records_count)
+
+      updated_ids = []
+      actual_updated_ids = []
+      while(records.present?) do
+        callbacks[:before_updating_a_part].call(part_count, part_total, updated_ids.size, records_count)
+        targets = records.slice!(0, BLOCK_SIZE)
+        out_updated_ids, out_actual_updated_ids, out_error = update_a_block_of_records(targets)
+        updated_ids += out_updated_ids
+        actual_updated_ids += out_actual_updated_ids
+        error |= out_error
+        callbacks[:before_updating_a_part].call(part_count, part_total, updated_ids.size, records_count)
+      end
+
+      callbacks[:after_updating].call(updated_ids.size)
+      return updated_ids, actual_updated_ids, error
+    end
+
+    def update_a_block_of_records(records)
+      record_ids = records.map { |target| target[:id] }
+      existing_records = target_model.where(:id => record_ids).index_by(&:id)
+      error = false
+      updated_ids = []
+      actual_updated_ids = []
+      ActiveRecord::Base.transaction do
+        records.each do |attributes|
+          id = attributes[:id]
+          model = existing_records[id]
+          attributes.each_pair do |column, value|
+            model[column] = converters.convert_value(column, value)
+          end
+          if model.changed?
+            if model.valid?
+              model.save!
+              actual_updated_ids << id
+            else
+              STDOUT.puts
+              STDOUT.puts "When id is #{model.id}: "
+              STDOUT.print get_errors(model.errors).pretty_inspect
+              error = true
+            end
+          end
+          updated_ids << id
+        end
+      end
+
+      return updated_ids, actual_updated_ids, error
+    end
+
+    def delete_waste_seed_records
+      seed_table = seed_part.seed_table
+      range_of_ids = seed_part.record_id_from .. seed_part.record_id_to
+
+      master_record_ids = target_model.where(:id => range_of_ids).pluck(:id)
+
+      seed_record_ids = SeedRecord.
+        by_seed_table_id(seed_table.id).
+        by_record_id(range_of_ids).
+        pluck(:record_id)
+
+      waste_record_ids = seed_record_ids - master_record_ids
+      SeedRecord.
+        by_seed_table_id(seed_table.id).
+        by_record_id(waste_record_ids).delete_all
+    end
+  end
+end

--- a/lib/seed_express/parts.rb
+++ b/lib/seed_express/parts.rb
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+module SeedExpress
+  class Parts
+    include Enumerable
+    extend Memoist
+
+    def initialize(seed_table, files, parts)
+      parts_keys = parts.keys
+      files_keys = files.keys
+
+      obsolete_keys = parts_keys - files_keys
+      new_keys = files_keys - parts_keys
+      existing_keys = files_keys & parts_keys
+
+      @obsolete_parts = part_objects(seed_table, obsolete_keys, files, parts)
+      alive_keys = existing_keys + new_keys
+      @alive_parts = part_objects(seed_table, alive_keys, files, parts)
+    end
+
+    def each(&block)
+      block ? @alive_parts.each(&block) : Enumerator.new(@alive_parts, :each)
+    end
+
+    def renew_digests!
+      SeedPart.where(:id => @obsolete_parts.map(&:id)).delete_all
+      self.each { |part| part.update_digest! }
+    end
+
+    def count
+      self.each.count
+    end
+
+    def size
+      self.count
+    end
+    memoize :size
+
+    private
+
+    def part_objects(seed_table, keys, files, parts)
+      keys.map do |key|
+        SeedPart.setup(seed_table, key, files[key], parts[key])
+      end
+    end
+  end
+end

--- a/lib/seed_express/railtie.rb
+++ b/lib/seed_express/railtie.rb
@@ -1,7 +1,8 @@
 class Railtie < Rails::Railtie
   initializer "seed_express" do
     Rails.application.config.paths["db/migrate"] << "#{File.dirname(__FILE__)}/../../db/migrate"
-    load "#{File.dirname(__FILE__)}/../../app/models/seed_record.rb"
-    load "#{File.dirname(__FILE__)}/../../app/models/seed_table.rb"
+    Dir.glob("#{File.dirname(__FILE__)}/../../app/models/*.rb").each do |file|
+      load file
+    end
   end
 end

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -21,12 +21,18 @@ module SeedExpress
       def define_pluck
         ActiveRecord::Relation.class_eval do
           return if self.instance_methods.include?(:pluck)
-          def pluck
-            if Array === args
-              self.select(args).map { |v| args.map { |column| v.send(column) }}
-            else
-              self.select(args).map { |v| v.send(args) }
-            end
+          def pluck(args)
+            Enumerable === args ? pluck_for_columns(args) : pluck_for_a_column(args)
+          end
+
+          private
+
+          def pluck_for_columns(args)
+            self.select(args).map { |record| args.map { |column| record.send(column) } }
+          end
+
+          def pluck_for_a_column(argv)
+            self.select(args).map { |record| record.send(argv) }
           end
         end
       end

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -11,23 +11,21 @@ module SeedExpress
 
       def define_to_h
         Enumerable.class_eval do
-          unless self.instance_methods.include?(:to_h)
-            define_method :to_h do
-              self.inject({}) { |h, (k, v)| h[k] = v; h }
-            end
+          return if self.instance_methods.include?(:to_h)
+          define_method :to_h do
+            self.inject({}) { |h, (k, v)| h[k] = v; h }
           end
         end
       end
 
       def define_pluck
         ActiveRecord::Relation.class_eval do
-          unless self.instance_methods.include?(:pluck)
-            define_method :pluck do |args|
-              if Array === args
-                self.select(args).map { |v| args.map { |column| v.send(column) }}
-              else
-                self.select(args).map { |v| v.send(args) }
-              end
+          return if self.instance_methods.include?(:pluck)
+          define_method :pluck do |args|
+            if Array === args
+              self.select(args).map { |v| args.map { |column| v.send(column) }}
+            else
+              self.select(args).map { |v| v.send(args) }
             end
           end
         end

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -12,7 +12,7 @@ module SeedExpress
       def define_to_h
         Enumerable.class_eval do
           return if self.instance_methods.include?(:to_h)
-          define_method :to_h do
+          def to_h
             self.inject({}) { |h, (k, v)| h[k] = v; h }
           end
         end
@@ -21,7 +21,7 @@ module SeedExpress
       def define_pluck
         ActiveRecord::Relation.class_eval do
           return if self.instance_methods.include?(:pluck)
-          define_method :pluck do |args|
+          def pluck
             if Array === args
               self.select(args).map { |v| args.map { |column| v.send(column) }}
             else

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+module SeedExpress
+  class Supporters
+    class << self
+      def regist!
+        define_to_h
+        define_pluck
+      end
+
+      private
+
+      def define_to_h
+        Enumerable.class_eval do
+          unless self.instance_methods.include?(:to_h)
+            define_method :to_h do
+              self.inject({}) { |h, (k, v)| h[k] = v; h }
+            end
+          end
+        end
+      end
+
+      def define_pluck
+        ActiveRecord::Relation.class_eval do
+          unless self.instance_methods.include?(:pluck)
+            define_method :pluck do |args|
+              if Array === args
+                self.select(args).map { |v| args.map { |column| v.send(column) }}
+              else
+                self.select(args).map { |v| v.send(args) }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -32,7 +32,7 @@ module SeedExpress
           end
 
           def pluck_for_a_column(argv)
-            self.select(args).map { |record| record.send(argv) }
+            self.select(argv).map { |record| record.send(argv) }
           end
         end
       end

--- a/lib/seed_express/version.rb
+++ b/lib/seed_express/version.rb
@@ -1,3 +1,3 @@
 module SeedExpress
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## 概要
- データファイルの分割に対応
- Code climate に怒られないようにコードを色々とリファクタリング
## データファイルの分割について
- ファイル名に、どこからどこの範囲の id を取り扱うファイルなのか含むようにする。
  - 例: `items` の id: 1 〜 1000 を含む場合、 items.000001-001000.csv
    - なんかもっと読みやすいファイル名が付けられるようだったら、そちらにしたい。
- 従来型の全てレコード含むファイルもサポートする。
  - この場合、内部的に id: 1〜(2**31 -1) のレコードと見なして動作する。
- 従来ファイルの digest 値は、 seed_tables に持たせてたが、
  上記の通り分割された関係で seed_parts にファイル単位で持つようになった。
