### PR TITLE
ダイジェスト更新時の total counter の誤りを修正

### DIFF
--- a/app/models/seed_record.rb
+++ b/app/models/seed_record.rb
@@ -76,15 +76,16 @@ class SeedRecord < ActiveRecord::Base
 
     def insert_digests!(seed_express, bulk_records)
       counter = 0
-      seed_express.callbacks[:before_inserting_digests].call(counter, bulk_records.size)
+      bulk_records_count = bulk_records.size
+      seed_express.callbacks[:before_inserting_digests].call(counter, bulk_records_count)
       while bulk_records.present?
-        seed_express.callbacks[:before_inserting_a_part_of_digests].call(counter, bulk_records.size)
+        seed_express.callbacks[:before_inserting_a_part_of_digests].call(counter, bulk_records_count)
         targets = bulk_records.slice!(0, BLOCK_SIZE)
         SeedRecord.import(targets)
         counter += targets.size
-        seed_express.callbacks[:after_inserting_a_part_of_digests].call(counter, bulk_records.size)
+        seed_express.callbacks[:after_inserting_a_part_of_digests].call(counter, bulk_records_count)
       end
-      seed_express.callbacks[:after_inserting_digests].call(counter, bulk_records.size)
+      seed_express.callbacks[:after_inserting_digests].call(counter, bulk_records_count)
     end
 
     def bulk_update_digests!(records)

--- a/lib/seed_express/version.rb
+++ b/lib/seed_express/version.rb
@@ -1,3 +1,3 @@
 module SeedExpress
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
## 概要

ダイジェスト更新時の total counter の誤りを修正
## 原因

total_counter を bulk_records.size から都度取得して callback を呼び出しているが、
その途中でも bulk_records そのものの件数が徐々に減っていっているため、
15000/1000 のように表示されていた。

このケースであれば、 15000/16000 が正しい。
