### PR TITLE
ID 重複の Validation の問題を修正

### DIFF
--- a/lib/seed_express/file.rb
+++ b/lib/seed_express/file.rb
@@ -22,6 +22,7 @@ module SeedExpress
     def values
       rows = self.reader.read_values_from(data)
       validate_range_of_ids(rows)
+      validate_duplicated_ids(rows)
       rows
     end
     memoize :values
@@ -39,6 +40,19 @@ module SeedExpress
         next if allowed_range.cover?(row[:id])
         raise "#{@file_info.file_path} contains out of range id(#{row[:id]})"
       end
+    end
+
+    def validate_duplicated_ids(rows)
+      duplicated_ids = Hash.new(0)
+      rows.each do |value|
+        duplicated_ids[value[:id]] += 1
+      end
+      duplicated_ids.delete_if do |k, v|
+        v == 1
+      end
+
+      return if duplicated_ids.blank?
+      raise "There are dupilcated ids. ({id=>num}: #{duplicated_ids.inspect})"
     end
   end
 end

--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -26,9 +26,6 @@ module SeedExpress
     def import
       return unless seed_part.updated?
 
-      # ID 重複を検出
-      detect_duplicated_ids
-
       # 削除されるレコードを削除
       deleted_ids = delete_missing_data
 
@@ -92,19 +89,6 @@ module SeedExpress
       end
 
       return inserting_records, updating_records, digests
-    end
-
-    def detect_duplicated_ids
-      duplicated_ids = Hash.new(0)
-      seed_part.values.each do |value|
-        duplicated_ids[value[:id]] += 1
-      end
-      duplicated_ids.delete_if do |k, v|
-        v == 1
-      end
-
-      return duplicated_ids.blank?
-      raise "There are dupilcated ids. ({id=>num}: #{duplicated_ids.inspect})"
     end
 
     def insert_records(records)


### PR DESCRIPTION
## 概要

ID 重複の Validation の問題を修正した。
検出しても条件式に誤りがあり、正しく動作していなかった。
## その他

検出機能そのものを SeedExpress::File に移動した。
これは、ファイルを読み込んだタイミングで行うことが最適と考えられることと、
Code Climate のスコアを悪化させないため。
