### PR TITLE
MySQL の sql_mode を strict(TRADITIONAL) に切り替える機能

### DIFF
--- a/lib/seed_express.rb
+++ b/lib/seed_express.rb
@@ -15,6 +15,7 @@ module SeedExpress
   autoload :File,       'seed_express/file'
   autoload :Supporters, 'seed_express/supporters'
   autoload :Utilities,  'seed_express/utilities'
+  autoload :Mysql,      'seed_express/mysql'
   autoload :ModelClass, 'seed_express/model_class'
   autoload :CSV,        'seed_express/csv'
   autoload :RubyHash,   'seed_express/ruby_hash'

--- a/lib/seed_express/mysql.rb
+++ b/lib/seed_express/mysql.rb
@@ -1,0 +1,21 @@
+module SeedExpress
+  class Mysql
+    class << self
+      def strict_mode
+        existing_sql_mode = self.sql_mode
+        self.sql_mode = 'TRADITIONAL'
+        yield
+      ensure
+        self.sql_mode = existing_sql_mode
+      end
+
+      def sql_mode
+        ActiveRecord::Base.connection.select_value("SELECT @@session.sql_mode")
+      end
+
+      def sql_mode=(v)
+        ActiveRecord::Base.connection.execute("SET session sql_mode = '#{v}'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

MySQL の sql_mode を strict(TRADITIONAL) に切り替える機能。
予めこのモードとすることで、以下を防ぐ。
- NULL 不許可でかつデフォルトの設定されていないカラムに勝手に 0 や '' が設定されること。
- 長過ぎる文字列を設定した際に勝手に超過分を切り捨てること。
## 使い方

以下を rake task に記述する。そのうち SeedExpress 内部で呼び出すようにする予定。

``` ruby
SeedExpress::MySQL.strict_mode do
    # ここに通常の SeedExpress の処理を記述する。
end
```
