### PR TITLE
Magic fields に対する validation を除外

### DIFF
--- a/lib/seed_express/model_validator.rb
+++ b/lib/seed_express/model_validator.rb
@@ -36,8 +36,11 @@ module SeedExpress
       def not_null_without_default_columns
         self.columns.select do |v|
           not_null_without_default_column?(v)
-        end.map(&:name).map(&:to_sym).
-          reject { |v| MAGIC_FIELD_NAMES.include?(v) }
+        end.map do |v|
+          symbol = v.name.to_sym
+          next if MAGIC_FIELD_NAMES.include?(symbol)
+          symbol
+        end.compact
       end
       memoize :not_null_without_default_columns
 

--- a/lib/seed_express/model_validator.rb
+++ b/lib/seed_express/model_validator.rb
@@ -31,10 +31,13 @@ module SeedExpress
     module ClassMethods
       extend Memoist
 
+      MAGIC_FIELD_NAMES = [:created_at, :created_on, :updated_at, :updated_on]
+
       def not_null_without_default_columns
         self.columns.select do |v|
           not_null_without_default_column?(v)
-        end.map(&:name).map(&:to_sym)
+        end.map(&:name).map(&:to_sym).
+          reject { |v| MAGIC_FIELD_NAMES.include?(v) }
       end
       memoize :not_null_without_default_columns
 


### PR DESCRIPTION
Magic fields に対する validation を除外した。
created_at, updated_at, created_on, updated_on は、
NOT NULL でかつ default が無いというケースは普通にありえることなので。
