### PR TITLE
外部定義の conversions に対応

### DIFF
--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -9,6 +9,7 @@ module SeedExpress
     attr_accessor :datetime_offset
     attr_accessor :callbacks
     attr_accessor :parent_validation
+    attr_accessor :user_defined_conversions
     attr_reader   :file_path
 
     include SeedExpress::Utilities
@@ -27,6 +28,7 @@ module SeedExpress
       self.nvl_mode = options[:nvl_mode]
       self.datetime_offset = options[:datetime_offset] || 0
       self.parent_validation = options[:parent_validation]
+      self.user_defined_conversions = options[:user_defined_conversions] || {}
     end
 
     def target_model
@@ -52,8 +54,9 @@ module SeedExpress
 
     def converters
       Converter.new(target_model,
-                    :nvl_mode        => nvl_mode,
-                    :datetime_offset => datetime_offset
+                    :nvl_mode                 => nvl_mode,
+                    :datetime_offset          => datetime_offset,
+                    :user_defined_conversions => user_defined_conversions,
                     )
     end
     memoize :converters

--- a/lib/seed_express/converter.rb
+++ b/lib/seed_express/converter.rb
@@ -17,11 +17,13 @@ module SeedExpress
     attr_reader :target_model
     attr_reader :nvl_mode
     attr_reader :datetime_offset
+    attr_reader :user_defined_conversions
 
     def initialize(target_model, options)
       @target_model = target_model
       @nvl_mode = !!options[:nvl_mode]
       @datetime_offset = options[:datetime_offset]
+      @user_defined_conversions = options[:user_defined_conversions]
     end
 
     def convert_value(column, value)
@@ -29,7 +31,8 @@ module SeedExpress
         return defaults_on_db[column] if defaults_on_db.has_key?(column)
         return nvl(column, value)
       end
-      conversion = DEFAULT_CONVERSIONS[columns[column].type]
+
+      conversion = conversions[columns[column].type]
       return value unless conversion
       conversion.call(self, value)
     end
@@ -38,6 +41,11 @@ module SeedExpress
       return nil unless nvl_mode
       nvl_columns[column]
     end
+
+    def conversions
+      DEFAULT_CONVERSIONS.merge(user_defined_conversions)
+    end
+    memoize :conversions
 
     private
 


### PR DESCRIPTION
外部定義の conversions(変換ロジック) に対応。
例えば、 boolean の true 一つとっても、以下のようにヴァリエーションがある。
* 1
* "1"
* true
* "true"

これを上手く解決するためのものである。
