### PR TITLE
入力データで未定義のカラムが更新される問題に対応

### DIFF
--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -205,7 +205,7 @@ module SeedExpress
       target_model.column_names.map(&:to_sym).reject do |v|
         next true if v == :created_at || v == :updated_at
         false
-      end
+      end.map { |v| [v, true] }.to_h
     end
     memoize :target_columns
 

--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -210,8 +210,10 @@ module SeedExpress
     memoize :target_columns
 
     def set_value_into_model!(record, model)
-      target_columns.each do |column|
-        model[column] = converters.convert_value(column, record[column])
+      available_columns = target_columns
+      record.each_pair do |column, value|
+        next if available_columns[column]
+        model[k] = converters.convert_value(column, value)
       end
     end
   end

--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -212,8 +212,8 @@ module SeedExpress
     def set_value_into_model!(record, model)
       available_columns = target_columns
       record.each_pair do |column, value|
-        next if available_columns[column]
-        model[k] = converters.convert_value(column, value)
+        next unless available_columns[column]
+        model[column] = converters.convert_value(column, value)
       end
     end
   end


### PR DESCRIPTION
入力データで未定義のカラムが更新される問題に対応した。
これまでは未定義の場合も nil を取得し、その nil が #to_i で 0 に、 #to_s で '' に置き換えられるため、不要な更新が行われていた。