### PR TITLE
ダイジェスト値を明示的に master server より読む

### DIFF
--- a/app/models/seed_part.rb
+++ b/app/models/seed_part.rb
@@ -45,10 +45,11 @@ class SeedPart < ActiveRecord::Base
 
   def existing_digests
     digests = {}
-    records =
+    records = ActiveRecord::Base.transaction do
       SeedRecord.where(:seed_table_id => seed_table.id,
                        :record_id => self.record_id_from .. self.record_id_to).
-      pluck([:record_id, :digest])
+        pluck([:record_id, :digest])
+    end
 
     records.each do |record_id, digest|
       digests[record_id] = digest

--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -48,7 +48,9 @@ module SeedExpress
     memoize :seed_table
 
     def parts
-      seed_table.parts
+      ActiveRecord::Base.transaction do
+        seed_table.parts
+      end
     end
     memoize :parts
 


### PR DESCRIPTION
ダイジェスト値を明示的に master server より読むようにした。
FORCE_UPDATE_MODE の場合に digest を無効にしても、レプリケーションまでに時間がかかり、 digest が無効化されていないという判断をすることがあったため。