### PR TITLE
schema の変更があった場合は強制アップデートが掛かるようにする

### DIFF
--- a/app/models/seed_table.rb
+++ b/app/models/seed_table.rb
@@ -53,6 +53,10 @@ class SeedTable < ActiveRecord::Base
     SeedRecord.by_seed_table_id(self.id).delete_all
   end
 
+  def schema_updated?
+    self.schema_digest != target_model.schema_digest
+  end
+
   class << self
     def get_record(target_model)
       table_name = target_model.table_name

--- a/app/models/seed_table.rb
+++ b/app/models/seed_table.rb
@@ -57,6 +57,12 @@ class SeedTable < ActiveRecord::Base
     self.schema_digest != target_model.schema_digest
   end
 
+  def update_schema_digest!
+    self.schema_digest = target_model.schema_digest
+    self.save!
+  end
+  alias renew_digest! update_schema_digest!
+
   class << self
     def get_record(target_model)
       table_name = target_model.table_name

--- a/db/migrate/20170110005921_add_schema_digest_to_seed_tables.rb
+++ b/db/migrate/20170110005921_add_schema_digest_to_seed_tables.rb
@@ -1,0 +1,5 @@
+class AddSchemaDigestToSeedTables < ActiveRecord::Migration
+  def change
+    add_column :seed_tables, :schema_digest, :string, :null => true, :after => :table_name
+  end
+end

--- a/lib/seed_express.rb
+++ b/lib/seed_express.rb
@@ -9,6 +9,7 @@ module SeedExpress
   autoload :Railtie,        'seed_express/railtie'
   Railtie
   autoload :Abstract,       'seed_express/abstract'
+  autoload :DigestManager,  'seed_express/digest_manager'
   autoload :Parts,          'seed_express/parts'
   autoload :Part,           'seed_express/part'
   autoload :Converter,      'seed_express/converter'

--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -159,6 +159,7 @@ module SeedExpress
       ActiveRecord::Base.transaction do
         seed_table.seed_records.renew_digests!(self, r[:inserted_ids], r[:updated_ids], r[:digests])
         self.parts.renew_digests!
+        seed_table.renew_digest!
       end
     end
 

--- a/lib/seed_express/abstract.rb
+++ b/lib/seed_express/abstract.rb
@@ -89,7 +89,7 @@ module SeedExpress
       with_elapsed_time do
         if truncate_mode
           truncate_table
-        elsif force_update_mode
+        elsif force_update_mode || seed_table.schema_updated?
           disable_digests
         end
 

--- a/lib/seed_express/digest_manager.rb
+++ b/lib/seed_express/digest_manager.rb
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+module SeedExpress
+  module DigestManager
+    private
+
+    def do_truncate_or_force_update
+      if truncate_mode
+        truncate_table
+      elsif need_disabling_digest?
+        disable_digests
+      end
+    end
+
+    def need_disabling_digest?
+      force_update_mode || seed_table.schema_updated?
+    end
+
+    def truncate_table
+      callbacks[:before_truncating].call
+      ActiveRecord::Base.transaction do
+        seed_table.truncate_digests
+      end
+
+      target_model.connection.execute("TRUNCATE TABLE #{@table_name}")
+      callbacks[:after_truncating].call
+    end
+
+    def disable_digests
+      callbacks[:before_disabling_digests].call
+      ActiveRecord::Base.transaction do
+        seed_table.disable_record_digests
+      end
+      callbacks[:before_disabling_digests].call
+    end
+
+    def renew_digests(r, has_an_error)
+      return if has_an_error
+      ActiveRecord::Base.transaction do
+        seed_table.seed_records.renew_digests!(self, r[:inserted_ids], r[:updated_ids], r[:digests])
+        self.parts.renew_digests!
+        seed_table.renew_digest!
+      end
+    end
+
+    def update_parent_digest_to_validate(args)
+      return unless self.parent_validation
+      parent_table = self.parent_validation
+      parent_table_model = ModelClass.from_table(parent_table)
+      SeedTable.get_record(parent_table_model).disable_record_digests(parent_ids(args))
+    end
+
+    def parent_ids(args)
+      parent_table = self.parent_validation
+      parent_id_column = (parent_table.to_s.singularize + "_id").to_sym
+      target_model.unscoped.where(:id => args[:inserted_ids] + args[:updated_ids]).
+        group(parent_id_column).pluck(parent_id_column)
+    end
+  end
+end

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -5,6 +5,7 @@ module SeedExpress
       def regist!
         define_to_h
         define_pluck
+        define_schema_digest
       end
 
       private
@@ -33,6 +34,20 @@ module SeedExpress
 
           def pluck_for_a_column(argv)
             self.select(argv).map { |record| record.send(argv) }
+          end
+        end
+      end
+
+      def define_schema_digest
+        ActiveRecord::Base.class_eval do
+          class << self
+            extend Memoist
+
+            def schema_digest
+              hash = self.columns.sort_by { |v| v.name }.map { |v| [v.name, v.sql_type] }.to_h
+              Digest::SHA1.hexdigest(hash.to_msgpack)
+            end
+            memoize :schema_digest
           end
         end
       end


### PR DESCRIPTION
schema の変更があった場合は強制アップデートが掛かるようにする。
動作としては FORCE_UPDATE_MODE と一緒である。
以下のようなケースで更新がされない件への対応。

1. あらかじめ CSV などに新規追加のカラムを追加。
    * schema の migrate はまだしていない。
2. 上記ファイルを seed_express にて登録。
3. schema を migrate。
4. 再度上記ファイルを seed_express にて登録。
     * ここでは digest が更新されていないので、登録処理がスキップされる。