### PR TITLE
ActiveSupport::Concern::MultipleIncludedBlocks Error & other tiny fixes.

### DIFF
--- a/app/models/seed_part.rb
+++ b/app/models/seed_part.rb
@@ -48,7 +48,7 @@ class SeedPart < ActiveRecord::Base
     records = ActiveRecord::Base.transaction do
       SeedRecord.where(:seed_table_id => seed_table.id,
                        :record_id => self.record_id_from .. self.record_id_to).
-        pluck([:record_id, :digest])
+        pluck(:record_id, :digest)
     end
 
     records.each do |record_id, digest|

--- a/lib/seed_express/model_class.rb
+++ b/lib/seed_express/model_class.rb
@@ -11,7 +11,7 @@ module SeedExpress
 
       def table_to_classes
         # Enables full of models
-        Find.find("#{Rails.root}/app/models") { |f| require f if /\.rb$/ === f }
+        Find.find("#{Rails.root}/app/models") { |f| require_dependency f if /\.rb$/ === f }
 
         get_real_classes = lambda do |models|
           results = []

--- a/lib/seed_express/model_class.rb
+++ b/lib/seed_express/model_class.rb
@@ -28,7 +28,7 @@ module SeedExpress
         not_abstract_classes = get_real_classes.call(ActiveRecord::Base.subclasses)
 
         not_abstract_classes.
-          select { |klass| !klass.abstract_class && klass.respond_to?(:table_name) }.
+          select { |klass| !klass.abstract_class? && klass.respond_to?(:table_name) }.
           map { |klass| [klass.table_name.to_sym, klass] }.to_h
       end
       memoize :table_to_classes

--- a/lib/seed_express/model_validator.rb
+++ b/lib/seed_express/model_validator.rb
@@ -56,7 +56,7 @@ module SeedExpress
       private
 
       def not_null_without_default_column?(column)
-        !column.primary && !column.null && column.default.nil?
+        !column.null && column.default.nil?
       end
     end
   end

--- a/lib/seed_express/parts.rb
+++ b/lib/seed_express/parts.rb
@@ -18,7 +18,7 @@ module SeedExpress
     end
 
     def each(&block)
-      block ? @alive_parts.each(&block) : Enumerator.new(@alive_parts, :each)
+      block ? @alive_parts.each(&block) : @alive_parts.enum_for(:each)
     end
 
     def renew_digests!


### PR DESCRIPTION
### Brief
We keep getting this exception when run rake task and found the following things to fix.
> ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern

### Patch contents
1. Use `ActiveSupport::Dependencies::Loadable#require_dependency` instead of `Kernel.#require`. 
2. Instead `Enumerator.new` without block with `Kernel#enum_for`
3. Fix improper `pluck` parameters. Passing an array to pluck generates wrong syntax SQL query.
4. Remove redundant undefined call `#primary`.
5. Avoid implicit conversion by using boolean method instead.