### PR TITLE
処理順を Update の後に Insert をするように変更

### DIFF
--- a/lib/seed_express/part.rb
+++ b/lib/seed_express/part.rb
@@ -40,11 +40,11 @@ module SeedExpress
       inserting_records, updating_records, digests =
         categorize_each_types_of_data_to_upload
 
-      # 新規登録するレコードを更新
-      insert_results = insert_records(inserting_records)
-
       # 更新するレコードを更新
       update_results = update_records(updating_records)
+
+      # 新規登録するレコードを更新
+      insert_results = insert_records(inserting_records)
 
       # 不要な digest を削除
       delete_waste_seed_records


### PR DESCRIPTION
処理順を Update の後に Insert をするように変更した。
レコードの Unique key の重複の際にも、ある程度うまく動作するようにするため。