### PR TITLE
pluck の ActiveRecord 4.0 以降のインターフェースに対応

### DIFF
--- a/app/models/seed_part.rb
+++ b/app/models/seed_part.rb
@@ -48,7 +48,7 @@ class SeedPart < ActiveRecord::Base
     records = ActiveRecord::Base.transaction do
       SeedRecord.where(:seed_table_id => seed_table.id,
                        :record_id => self.record_id_from .. self.record_id_to).
-        pluck([:record_id, :digest])
+        pluck(:record_id, :digest)
     end
 
     records.each do |record_id, digest|

--- a/lib/seed_express/supporters.rb
+++ b/lib/seed_express/supporters.rb
@@ -22,13 +22,24 @@ module SeedExpress
       def define_pluck
         ActiveRecord::Relation.class_eval do
           return if self.instance_methods.include?(:pluck)
-          def pluck(args)
-            Enumerable === args ? pluck_for_columns(args) : pluck_for_a_column(args)
+          def pluck(*args)
+            if args.size > 1
+              # Compatible for ActiveRecord 4.0(or later), multipluck 0.0.5(or later)
+              pluck_for_columns(*args)
+            else
+              # Compatible for multipluck 0.0.4(or earlier)
+              first = args.first
+              if Enumerable === first
+                pluck_for_columns(*first)
+              else
+                pluck_for_a_column(first)
+              end
+            end
           end
 
           private
 
-          def pluck_for_columns(args)
+          def pluck_for_columns(*args)
             self.select(args).map { |record| args.map { |column| record.send(column) } }
           end
 


### PR DESCRIPTION
pluck の ActiveRecord 4.0 以降のインターフェースに対応した。

* ActiveRecord 3.0 の場合
    * 内部で実装している pluck を ActiveRecord 4.0 のインターフェースでも動作するようにした。
* ActiveRecord 3.2 以降の場合
    * multipliuck 1.0.1 以降を使う
