### PR TITLE
Enumerator.new の代わりに #enum_for を使うように変更

### DIFF
--- a/lib/seed_express/parts.rb
+++ b/lib/seed_express/parts.rb
@@ -18,7 +18,7 @@ module SeedExpress
     end
 
     def each(&block)
-      block ? @alive_parts.each(&block) : Enumerator.new(@alive_parts, :each)
+      block ? @alive_parts.each(&block) : @alive_parts.enum_for(:each)
     end
 
     def renew_digests!


### PR DESCRIPTION
次のコミットの反映。
https://github.com/aktsk/seed_express/pull/41/commits/a296ca0a7c90eda79297c7d9e405f4314d941e9c
