### PR TITLE
モデルファイルのロード時に隠しファイルを読み込まない

### DIFF
--- a/lib/seed_express/model_class.rb
+++ b/lib/seed_express/model_class.rb
@@ -11,7 +11,12 @@ module SeedExpress
 
       def table_to_classes
         # Enables full of models
-        Find.find("#{Rails.root}/app/models") { |f| require_dependency f if /\.rb$/ === f }
+        Find.find("#{Rails.root}/app/models") do |f|
+          next unless /\.rb$/ === f
+          next if %r!/\.! === f
+
+          require_dependency f
+        end
 
         get_real_classes = lambda do |models|
           results = []


### PR DESCRIPTION
モデルファイルのロード時に隠しファイルを読み込まない。
.AppleDouble などの下にある .rb ファイル(中身は Ruby コードじゃない)を主なターゲットとする。